### PR TITLE
fix warning on get_segment_manager()

### DIFF
--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -408,11 +408,11 @@ namespace chainbase {
             _index_list.push_back( new_index );
          }
 
-         auto get_segment_manager() -> decltype( ((pinnable_mapped_file*)nullptr)->get_segment_manager()) {
+         pinnable_mapped_file::segment_manager* get_segment_manager() {
             return _db_file.get_segment_manager();
          }
 
-         auto get_segment_manager()const -> std::add_const_t< decltype( ((pinnable_mapped_file*)nullptr)->get_segment_manager() ) > {
+         const pinnable_mapped_file::segment_manager* get_segment_manager() const {
             return _db_file.get_segment_manager();
          }
 


### PR DESCRIPTION
Not really sure why it was originally implemented the way it was -- causes a lot of warning spam with gcc. Seems fine to change it like this (and it's the change that went in to the old EOSIO chainbase too it seems)